### PR TITLE
ENH:  Cleaner LEEM triggering definition

### DIFF
--- a/startup/46-ESM_LEEM.py
+++ b/startup/46-ESM_LEEM.py
@@ -26,7 +26,7 @@ class LEEMDetector(Device):
                 self.acquire.clear_sub(check_if_done)
 
         self.acquire.subscribe(check_if_done, run=False)
-        self.acquire.set(1)
+        self.acquire.put(1)
         return status
 
 

--- a/startup/46-ESM_LEEM.py
+++ b/startup/46-ESM_LEEM.py
@@ -18,23 +18,19 @@ class LEEMDetector(Device):
 #        self.st = None
 
     def trigger(self):
-        init = 0
         status = DeviceStatus(self)
         # Write to server.
         def check_if_done(old_value, value, **kwargs):
-            if init == 1:
-                if value == 0 and old_value == 1:
-                    status._finished()
-                    self.acquire.clear_sub(check_if_done)
+            if value == 0 and old_value == 1:
+                status._finished()
+                self.acquire.clear_sub(check_if_done)
 
-        self.acquire.subscribe(check_if_done)
+        self.acquire.subscribe(check_if_done, run=False)
         self.acquire.set(1)
-        init = 1
         return status
 
 
 leem_det = LEEMDetector('XF:21ID2{LEEM}:', name='leem_det')
-#leem_det.trigger()
 
 
 def LEEM_plan(grating='600', EPU='105', E_start=100, E_stop=150, E_step=0.1):


### PR DESCRIPTION
This is a revisit of this pull request below, as a cleaner way of using the callback
https://github.com/NSLS-II-ESM-1/profile_collection/pull/6

I ran into this problem again this past week, and Tom suggested using subscribe with run=False, to get around the problem calling the function and finishing before the acquire put is even made.

Previously, there was also some code 
```py
def __init__(self, *args, **kwargs):
        def check_if_done(value, old_value, **kwargs):
            st = self.st
            if st is not None:
                if value == 0 and old_value == 1:
                    st._finished()
                    self.st = None

        super().__init__(*args, **kwargs)
        # On a background thread, listen for the server's response.
        self.start_acq.subscribe(check_if_done)
        self.st = None
````
But I wasn't sure of the purpose of this.  Is this to deal with the possibility of the run engine starting when the acquisition in progress?  Or why would we need this code in the init?

